### PR TITLE
thumbextractor: add support for http filenames

### DIFF
--- a/config
+++ b/config
@@ -1,9 +1,14 @@
 ngx_addon_name=ngx_http_video_thumbextractor_module
-ngx_feature_libs="-lavformat -lavcodec -lavutil -lavfilter -lswscale -lswresample -lpostproc -ljpeg"
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES $ngx_addon_name"
-CORE_INCS="$CORE_INCS \
-    $ngx_addon_dir/src \
-    $ngx_addon_dir/include"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
-    ${ngx_addon_dir}/src/ngx_http_video_thumbextractor_module.c"
-CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
+ngx_module_libs="-lavformat -lavcodec -lavutil -lavfilter -lswscale -lswresample -lpostproc -ljpeg"
+ngx_module_type=HTTP_AUX_FILTER
+ngx_module_incs="$ngx_addon_dir/include $ngx_addon_dir/src"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_name=$ngx_addon_name
+    ngx_module_srcs="${ngx_addon_dir}/src/ngx_http_video_thumbextractor_module.c"
+    . auto/module
+else
+    HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES $ngx_addon_name"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
+        ${ngx_addon_dir}/src/ngx_http_video_thumbextractor_module.c"
+fi

--- a/config
+++ b/config
@@ -1,14 +1,14 @@
 ngx_addon_name=ngx_http_video_thumbextractor_module
 ngx_module_libs="-lavformat -lavcodec -lavutil -lavfilter -lswscale -lswresample -lpostproc -ljpeg"
-ngx_module_type=HTTP_AUX_FILTER
 ngx_module_incs="$ngx_addon_dir/include $ngx_addon_dir/src"
 
 if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
     ngx_module_name=$ngx_addon_name
     ngx_module_srcs="${ngx_addon_dir}/src/ngx_http_video_thumbextractor_module.c"
     . auto/module
 else
-    HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES $ngx_addon_name"
+    HTTP_MODULES="$HTTP_MODULES $ngx_addon_name"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
         ${ngx_addon_dir}/src/ngx_http_video_thumbextractor_module.c"
 fi

--- a/include/ngx_http_video_thumbextractor_module.h
+++ b/include/ngx_http_video_thumbextractor_module.h
@@ -112,9 +112,7 @@ typedef struct {
     ngx_http_video_thumbextractor_transfer_t    transfer;
 } ngx_http_video_thumbextractor_ctx_t;
 
-ngx_int_t ngx_http_video_thumbextractor_access_handler(ngx_http_request_t *r);
-ngx_int_t ngx_http_video_thumbextractor_filter_init(ngx_conf_t *cf);
-
+static ngx_int_t ngx_http_video_thumbextractor_handler(ngx_http_request_t *r);
 
 static ngx_str_t NGX_HTTP_VIDEO_THUMBEXTRACTOR_CONTENT_TYPE = ngx_string("image/jpeg");
 

--- a/src/ngx_http_video_thumbextractor_module.c
+++ b/src/ngx_http_video_thumbextractor_module.c
@@ -149,12 +149,10 @@ ngx_http_video_thumbextractor_set_request_context(ngx_http_request_t *r)
     ngx_http_video_thumbextractor_ctx_t         *ctx;
     ngx_http_video_thumbextractor_thumb_ctx_t   *thumb_ctx;
     ngx_pool_cleanup_t                          *cln;
-    ngx_http_core_loc_conf_t                    *clcf;
     ngx_str_t                                    vv_filename = ngx_null_string, vv_second = ngx_null_string;
     ngx_str_t                                    vv_value = ngx_null_string;
 
     vtlcf = ngx_http_get_module_loc_conf(r, ngx_http_video_thumbextractor_module);
-    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_video_thumbextractor_module);
 
@@ -213,12 +211,12 @@ ngx_http_video_thumbextractor_set_request_context(ngx_http_request_t *r)
         return NGX_HTTP_BAD_REQUEST;
     }
 
-    if ((thumb_ctx->filename.data = ngx_pcalloc(r->pool, clcf->root.len + vv_filename.len + 1)) == NULL) {
+    if ((thumb_ctx->filename.data = ngx_pcalloc(r->pool, vv_filename.len + 1)) == NULL) {
         ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0, "video thumb extractor module: unable to allocate memory to store full filename");
         return NGX_ERROR;
     }
-    ngx_memcpy(ngx_copy(thumb_ctx->filename.data, clcf->root.data, clcf->root.len), vv_filename.data, vv_filename.len);
-    thumb_ctx->filename.len = clcf->root.len + vv_filename.len;
+    ngx_memcpy(thumb_ctx->filename.data, vv_filename.data, vv_filename.len);
+    thumb_ctx->filename.len = vv_filename.len;
     thumb_ctx->filename.data[thumb_ctx->filename.len] = '\0';
 
     return NGX_OK;

--- a/src/ngx_http_video_thumbextractor_module_setup.c
+++ b/src/ngx_http_video_thumbextractor_module_setup.c
@@ -33,7 +33,6 @@ static char *ngx_http_video_thumbextractor_init_main_conf(ngx_conf_t *cf, void *
 static void *ngx_http_video_thumbextractor_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_video_thumbextractor_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child);
 
-static ngx_int_t ngx_http_video_thumbextractor_post_config(ngx_conf_t *cf);
 static ngx_int_t ngx_http_video_thumbextractor_init_worker(ngx_cycle_t *cycle);
 static void      ngx_http_video_thumbextractor_exit_worker(ngx_cycle_t *cycle);
 
@@ -190,7 +189,7 @@ static ngx_command_t  ngx_http_video_thumbextractor_commands[] = {
 
 static ngx_http_module_t  ngx_http_video_thumbextractor_module_ctx = {
     NULL,                                           /* preconfiguration */
-    ngx_http_video_thumbextractor_post_config,      /* postconfiguration */
+    NULL,                                           /* postconfiguration */
 
     ngx_http_video_thumbextractor_create_main_conf, /* create main configuration */
     ngx_http_video_thumbextractor_init_main_conf,   /* init main configuration */
@@ -345,24 +344,6 @@ ngx_http_video_thumbextractor_merge_loc_conf(ngx_conf_t *cf, void *parent, void 
 
 
 static ngx_int_t
-ngx_http_video_thumbextractor_post_config(ngx_conf_t *cf)
-{
-    ngx_int_t                        rc;
-
-    if (!ngx_http_video_thumbextractor_used) {
-        return NGX_OK;
-    }
-
-    /* register our output filters */
-    if ((rc = ngx_http_video_thumbextractor_filter_init(cf)) != NGX_OK) {
-        return rc;
-    }
-
-    return NGX_OK;
-}
-
-
-static ngx_int_t
 ngx_http_video_thumbextractor_init_worker(ngx_cycle_t *cycle)
 {
     ngx_uint_t i;
@@ -403,10 +384,12 @@ ngx_http_video_thumbextractor_exit_worker(ngx_cycle_t *cycle)
 static char *
 ngx_http_video_thumbextractor(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    ngx_http_core_loc_conf_t                 *clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
     ngx_http_video_thumbextractor_loc_conf_t *vtlcf = conf;
 
+    clcf->handler = ngx_http_video_thumbextractor_handler;
+
     vtlcf->enabled = 1;
-    ngx_http_video_thumbextractor_used = 1;
 
     return NGX_CONF_OK;
 }

--- a/src/ngx_http_video_thumbextractor_module_utils.c
+++ b/src/ngx_http_video_thumbextractor_module_utils.c
@@ -72,7 +72,7 @@ ngx_http_video_thumbextractor_get_thumb(ngx_http_video_thumbextractor_loc_conf_t
     // Open video file
     if ((ret = avformat_open_input(&pFormatCtx, filename, NULL, NULL)) != 0) {
         ngx_log_error(NGX_LOG_ERR, log, 0, "video thumb extractor module: Couldn't open file %s, error: %d, %s", filename, ret, av_err2str(ret));
-        rc = (ret == AVERROR(NGX_ENOENT)) ? NGX_HTTP_VIDEO_THUMBEXTRACTOR_FILE_NOT_FOUND : NGX_ERROR;
+        rc = (ret == AVERROR(NGX_ENOENT) || ret == AVERROR_HTTP_NOT_FOUND) ? NGX_HTTP_VIDEO_THUMBEXTRACTOR_FILE_NOT_FOUND : NGX_ERROR;
         goto exit;
     }
 


### PR DESCRIPTION
Drop secondary fd read/seek, root dir combining with filename arg so
exact filename is passed to avformat_open_input().

Use avformat_seek_file and add stream start_time to seek calculations.

Remove deprecated ffmpeg 3.x av_register() calls.

config: compile as dynamic module